### PR TITLE
Resolve compiler errors and warnings on UE 4.22.2

### DIFF
--- a/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/AnimNode_MotionField.cpp
+++ b/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/AnimNode_MotionField.cpp
@@ -87,9 +87,9 @@ void FAnimNode_MotionField::Initialize_AnyThread(const FAnimationInitializeConte
 	for (int i = 0; i < MotionField->MotionBones.Num(); i++)
 	{
 		FJointData JD = FJointData();
-		FVector Vel = Context.AnimInstanceProxy->GetSkelMeshComponent()->GetPhysicsLinearVelocity(MotionField->MotionBones[i]);
-		float Size = Vel.Size();
-		JD.BoneCSVel = Context.AnimInstanceProxy->GetComponentTransform().InverseTransformVectorNoScale(Vel.GetSafeNormal()) * Size;
+		FVector Velocity = Context.AnimInstanceProxy->GetSkelMeshComponent()->GetPhysicsLinearVelocity(MotionField->MotionBones[i]);
+		float Size = Velocity.Size();
+		JD.BoneCSVel = Context.AnimInstanceProxy->GetComponentTransform().InverseTransformVectorNoScale(Velocity.GetSafeNormal()) * Size;
 		JD.BoneCSPos = Context.AnimInstanceProxy->GetSkelMeshComponent()->GetSocketTransform(MotionField->MotionBones[i], RTS_Component).GetTranslation();
 
 		JointsData.Add(JD);
@@ -172,7 +172,6 @@ void FAnimNode_MotionField::Evaluate_AnyThread(FPoseContext & Output)
 		Pose2.Pose.CopyBonesFrom(LastBones);
 		FAnimationRuntime::BlendTwoPosesTogether(Pose1.Pose, Pose2.Pose, Pose1.Curve, Pose2.Curve, BlendTimer / BlendTime, Output.Pose, Output.Curve);
 
-		/*
 		if (UAnimSequence* LastSequence = GetLastAnim())
 		{
 		LastSequence->GetAnimationPose(Pose2.Pose, Pose2.Curve, FAnimExtractContext(LastAnimTime, true));
@@ -342,10 +341,10 @@ void FAnimNode_MotionField::PreEvaluate(const FAnimationUpdateContext & Context)
 				FTransform BoneTM = Context.AnimInstanceProxy->GetSkelMeshComponent()->GetSocketTransform(MotionField->MotionBones[i], RTS_Component);
 				//FMotionKeyUtils::GetAnimBoneLocalTM(GetCurrentAnim(), CurrentAnimTime, CurrentIndex, BoneTM);
 
-				const FVector Vel = BoneTM.GetTranslation() - JointsData[i].BoneCSPos;
+				const FVector Velocity = BoneTM.GetTranslation() - JointsData[i].BoneCSPos;
 				//Context.AnimInstanceProxy->GetSkelMeshComponent()->GetPhysicsLinearVelocity(MotionField->MotionBones[i]);
 
-				JointsData[i].BoneCSVel = (Vel.GetSafeNormal()) * (Vel.Size() / DT);
+				JointsData[i].BoneCSVel = (Velocity.GetSafeNormal()) * (Velocity.Size() / DT);
 				JointsData[i].BoneCSPos = BoneTM.GetTranslation();
 			}
 

--- a/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/AnimNode_MotionMatching.cpp
+++ b/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/AnimNode_MotionMatching.cpp
@@ -18,7 +18,7 @@ bool FMotionAnim::ApplyTime(const float DT, const float InBlendTime, const bool 
 	{
 		BlendTime = FMath::Clamp(BlendTime - DT, 0.f, InBlendTime);
 		
-		if ((BlendTime == 0.f))
+		if (BlendTime == 0.f)
 		{
 			return true;
 		}

--- a/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/MotionCharacter.cpp
+++ b/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/MotionCharacter.cpp
@@ -213,7 +213,7 @@ void AMotionCharacter::DrawDebugMotionData(const float LifeTime)
 		FVector LastPos = RootTM.TransformPosition(JointsData[i].BoneCSPos);
 		FVector LastVel = RootTM.TransformVector(JointsData[i].BoneCSVel.GetSafeNormal()) * JointsData[i].BoneCSVel.Size();
 
-		DrawDebugSphere(GetWorld(), LastPos, 10.f, 12, FColor::Yellow, false, LifeTime, .5f);
+		DrawDebugSphere(GetWorld(), LastPos, 10.f, 12, FColor::Yellow, false, LifeTime, 0, 0.5f);
 		//FTransform BoneTM = Context.AnimInstanceProxy->GetSkelMeshComponent()->GetSocketTransform(MotionField->MotionBones[i], RTS_Component) * RootTM;
 		//Context.AnimInstanceProxy->AnimDrawDebugSphere(BoneTM.GetTranslation(), 10.f, 12, FColor::Magenta, false, LifeTime, 0.5f);
 
@@ -231,7 +231,7 @@ void AMotionCharacter::DrawDebugMotionData(const float LifeTime)
 
 		FVector WinnerPos = RootTM.TransformPosition(MotionField->MotionKeys[MotionKeyIndex].MotionJointData[i].BoneCSPos);
 		FVector WinnerVel = RootTM.TransformVector(MotionField->MotionKeys[MotionKeyIndex].MotionJointData[i].BoneCSVel.GetSafeNormal()) * MotionField->MotionKeys[MotionKeyIndex].MotionJointData[i].BoneCSVel.Size();
-		DrawDebugSphere(GetWorld(), WinnerPos, 10.f, 12, FColor::Green, false, LifeTime, 2.f);
+		DrawDebugSphere(GetWorld(), WinnerPos, 10.f, 12, FColor::Green, false, LifeTime, 0, 2.f);
 		DrawDebugLine
 		(
 			GetWorld(),

--- a/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/MotionKey.cpp
+++ b/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/MotionKey.cpp
@@ -67,7 +67,7 @@ void FMotionKey::ExtractDataFromAnimation(const UAnimSequence * InSequence, cons
 		FMotionKeyUtils::ExtractAnimTrajectory(FutureTrajectory, InSequence, StartTime);
 
 #if WITH_EDITOR
-			FName SrcAnimationName = InSequence->GetFName();
+			SrcAnimationName = InSequence->GetFName();
 #endif // WITH_EDITOR
 	}
 

--- a/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/MotionKeyUtils.cpp
+++ b/UE_MotMatch/Plugins/MotionMatching/Source/MotionMatching/Private/MotionKeyUtils.cpp
@@ -310,8 +310,6 @@ float FMotionKeyUtils::CompareJointDatas(const TArray<FJointData> JointData_A, c
 			PoseCost += JointData_A[i].CompareTo(JointData_B[i]);
 		}
 
-		PoseCost;
-
 		return PoseCost;
 	}
 	return -666.f;


### PR DESCRIPTION
Ran into a few small errors which prevented me from compiling the project with the current version of UE4. This merge contains fixes for these, as well as a few minor warnings to get clean output from the compiler when building.